### PR TITLE
Update to 2.0.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,9 @@ org.gradle.jvmargs=-Xmx4G
 	loader_version=0.14.10
 
 # Mod Properties
-	mod_version = 1.18.2-Fabric-2.0.1.0
+	mod_version = 1.18.2-Fabric-2.0.1.1
 	maven_group = com.modularmods.mcgltf
 	archives_base_name = MCglTF
 
 # Dependencies
-	fabric_version=0.66.0+1.18.2
+	fabric_version=0.67.0+1.18.2

--- a/src/main/java/com/modularmods/mcgltf/iris/IrisRenderingHook.java
+++ b/src/main/java/com/modularmods/mcgltf/iris/IrisRenderingHook.java
@@ -143,6 +143,8 @@ public class IrisRenderingHook {
 		
 		if(phase != WorldRenderingPhase.NONE) {
 			int currentProgram = shaderInstance.getId();
+			RenderedGltfModel.MODEL_VIEW_MATRIX = GL20.glGetUniformLocation(currentProgram, "iris_ModelViewMat");
+			RenderedGltfModel.NORMAL_MATRIX = GL20.glGetUniformLocation(currentProgram, "iris_NormalMat");
 			int normals = GL20.glGetUniformLocation(currentProgram, "normals");
 			int specular = GL20.glGetUniformLocation(currentProgram, "specular");
 			

--- a/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL30Iris.java
+++ b/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL30Iris.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Triple;
+import org.lwjgl.opengl.GL20;
 
 import com.google.gson.Gson;
 import com.modularmods.mcgltf.RenderedGltfModelGL30;
 import com.modularmods.mcgltf.mixin.Matrix4fAccessor;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 
 import de.javagl.jgltf.model.GltfModel;
@@ -67,13 +69,23 @@ public class RenderedGltfModelGL30Iris extends RenderedGltfModelGL30 {
 		accessor.setM31(transform[13]);
 		accessor.setM32(transform[14]);
 		accessor.setM33(transform[15]);
+
+		if(NORMAL_MATRIX != -1) {
+			Matrix3f normal = new Matrix3f(pose);
+			normal.transpose();
+			Matrix3f currentNormal = CURRENT_NORMAL.copy();
+			currentNormal.mul(normal);
+			
+			currentNormal.store(BUF_FLOAT_9);
+			GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+		}
 		
 		pose.transpose();
 		Matrix4f currentPose = CURRENT_POSE.copy();
 		currentPose.multiply(pose);
 		
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
 	}
 
 	@Override

--- a/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL33Iris.java
+++ b/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL33Iris.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Triple;
+import org.lwjgl.opengl.GL20;
 
 import com.google.gson.Gson;
 import com.modularmods.mcgltf.RenderedGltfModelGL33;
 import com.modularmods.mcgltf.mixin.Matrix4fAccessor;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 
 import de.javagl.jgltf.model.GltfModel;
@@ -71,13 +73,23 @@ public class RenderedGltfModelGL33Iris extends RenderedGltfModelGL33 {
 		accessor.setM31(transform[13]);
 		accessor.setM32(transform[14]);
 		accessor.setM33(transform[15]);
+
+		if(NORMAL_MATRIX != -1) {
+			Matrix3f normal = new Matrix3f(pose);
+			normal.transpose();
+			Matrix3f currentNormal = CURRENT_NORMAL.copy();
+			currentNormal.mul(normal);
+			
+			currentNormal.store(BUF_FLOAT_9);
+			GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+		}
 		
 		pose.transpose();
 		Matrix4f currentPose = CURRENT_POSE.copy();
 		currentPose.multiply(pose);
 		
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
 	}
 
 	@Override

--- a/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL40Iris.java
+++ b/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelGL40Iris.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Triple;
+import org.lwjgl.opengl.GL20;
 
 import com.google.gson.Gson;
 import com.modularmods.mcgltf.RenderedGltfModelGL40;
 import com.modularmods.mcgltf.mixin.Matrix4fAccessor;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 
 import de.javagl.jgltf.model.GltfModel;
@@ -71,13 +73,23 @@ public class RenderedGltfModelGL40Iris extends RenderedGltfModelGL40 {
 		accessor.setM31(transform[13]);
 		accessor.setM32(transform[14]);
 		accessor.setM33(transform[15]);
+
+		if(NORMAL_MATRIX != -1) {
+			Matrix3f normal = new Matrix3f(pose);
+			normal.transpose();
+			Matrix3f currentNormal = CURRENT_NORMAL.copy();
+			currentNormal.mul(normal);
+			
+			currentNormal.store(BUF_FLOAT_9);
+			GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+		}
 		
 		pose.transpose();
 		Matrix4f currentPose = CURRENT_POSE.copy();
 		currentPose.multiply(pose);
 		
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
 	}
 
 	@Override

--- a/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelIris.java
+++ b/src/main/java/com/modularmods/mcgltf/iris/RenderedGltfModelIris.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import com.modularmods.mcgltf.MCglTF;
 import com.modularmods.mcgltf.RenderedGltfModel;
 import com.modularmods.mcgltf.mixin.Matrix4fAccessor;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 
 import de.javagl.jgltf.model.GltfModel;
@@ -77,12 +78,22 @@ public class RenderedGltfModelIris extends RenderedGltfModel {
 		accessor.setM32(transform[14]);
 		accessor.setM33(transform[15]);
 		
+		if(NORMAL_MATRIX != -1) {
+			Matrix3f normal = new Matrix3f(pose);
+			normal.transpose();
+			Matrix3f currentNormal = CURRENT_NORMAL.copy();
+			currentNormal.mul(normal);
+			
+			currentNormal.store(BUF_FLOAT_9);
+			GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+		}
+		
 		pose.transpose();
 		Matrix4f currentPose = CURRENT_POSE.copy();
 		currentPose.multiply(pose);
 		
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
 	}
 
 	@Override


### PR DESCRIPTION
Update to fix a compatibility issue with Iris Shaders v1.4.3. (1.16.5 does not affected)
You are now need to assign normal matrix from `PoseStack.last().normal().copy()` to `RenderedGltfModel.CURRENT_NORMAL` when Iris Shaders is active.
Please refer to the change at ExampleItemRendererIris, ExampleEntityRendererIris, and ExampleBlockEntityRendererIris in MCglTF-Example.