### PR TITLE
Update to 2.0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.12.2-Forge-2.0.0.1'
+version = '1.12.2-Forge-2.0.2.0'
 group = 'com.modularmods.mcgltf' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'MCglTF'
 

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
@@ -433,6 +433,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -552,6 +572,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -664,6 +704,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		int count = positionsAccessorModel.getCount();
@@ -775,6 +835,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -881,6 +961,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		int count = positionsAccessorModel.getCount();
@@ -1143,6 +1243,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1345,6 +1465,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1537,6 +1677,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {
@@ -1733,6 +1893,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1924,6 +2104,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL20.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL20.java
@@ -138,6 +138,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -146,6 +163,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -266,6 +292,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -274,6 +317,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -383,6 +435,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 			bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 		}
 		AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+		AccessorModel texcoords1AccessorModelFinal;
+		
+		texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoordsAccessorModel != null) {
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+			texcoords1AccessorModelFinal = texcoordsAccessorModel;
+		}
+		else {
+			texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+		}
+		
 		renderCommand.add(() -> {
 			GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 			GL11.glTexCoordPointer(
@@ -391,6 +460,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 					texcoordsAccessorModelFinal.getByteStride(),
 					texcoordsAccessorModelFinal.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+			
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+					texcoords1AccessorModelFinal.getComponentType(),
+					false,
+					texcoords1AccessorModelFinal.getByteStride(),
+					texcoords1AccessorModelFinal.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		});
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -506,6 +584,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -514,6 +609,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -622,6 +726,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 			bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 		}
 		AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+		AccessorModel texcoords1AccessorModelFinal;
+		
+		texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoordsAccessorModel != null) {
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+			texcoords1AccessorModelFinal = texcoordsAccessorModel;
+		}
+		else {
+			texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+		}
+		
 		renderCommand.add(() -> {
 			GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 			GL11.glTexCoordPointer(
@@ -630,6 +751,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 					texcoordsAccessorModelFinal.getByteStride(),
 					texcoordsAccessorModelFinal.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+			
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+					texcoords1AccessorModelFinal.getComponentType(),
+					false,
+					texcoords1AccessorModelFinal.getByteStride(),
+					texcoords1AccessorModelFinal.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		});
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -761,6 +891,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -769,6 +916,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -909,6 +1065,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -917,6 +1090,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -1064,6 +1246,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 			bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 		}
 		AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+		AccessorModel texcoords1AccessorModelFinal;
+		
+		texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoordsAccessorModel != null) {
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+			texcoords1AccessorModelFinal = texcoordsAccessorModel;
+		}
+		else {
+			texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+		}
+		
 		renderCommand.add(() -> {
 			GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 			GL11.glTexCoordPointer(
@@ -1072,6 +1271,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 					texcoordsAccessorModelFinal.getByteStride(),
 					texcoordsAccessorModelFinal.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+			
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+					texcoords1AccessorModelFinal.getComponentType(),
+					false,
+					texcoords1AccessorModelFinal.getByteStride(),
+					texcoords1AccessorModelFinal.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		});
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1197,6 +1405,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 			}
 			AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+			AccessorModel texcoords1AccessorModelFinal;
+			
+			texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoordsAccessorModel != null) {
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+				texcoords1AccessorModelFinal = texcoordsAccessorModel;
+			}
+			else {
+				texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+			}
+			
 			renderCommand.add(() -> {
 				GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 				GL11.glTexCoordPointer(
@@ -1205,6 +1430,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 						texcoordsAccessorModelFinal.getByteStride(),
 						texcoordsAccessorModelFinal.getByteOffset());
 				GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+				
+				GL20.glVertexAttribPointer(
+						mc_midTexCoord,
+						texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+						texcoords1AccessorModelFinal.getComponentType(),
+						false,
+						texcoords1AccessorModelFinal.getByteStride(),
+						texcoords1AccessorModelFinal.getByteOffset());
+				GL20.glEnableVertexAttribArray(mc_midTexCoord);
 			});
 		}
 		
@@ -1335,6 +1569,23 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 			bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel(), renderCommand);
 		}
 		AccessorModel texcoordsAccessorModelFinal = texcoordsAccessorModel;
+		AccessorModel texcoords1AccessorModelFinal;
+		
+		texcoordsAccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoordsAccessorModel != null) {
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+			texcoords1AccessorModelFinal = texcoordsAccessorModel;
+		}
+		else {
+			texcoords1AccessorModelFinal = texcoordsAccessorModelFinal;
+		}
+		
 		renderCommand.add(() -> {
 			GL13.glClientActiveTexture(COLOR_MAP_INDEX);
 			GL11.glTexCoordPointer(
@@ -1343,6 +1594,15 @@ public class RenderedGltfModelGL20 extends RenderedGltfModelGL30 {
 					texcoordsAccessorModelFinal.getByteStride(),
 					texcoordsAccessorModelFinal.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+			
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoords1AccessorModelFinal.getElementType().getNumComponents(),
+					texcoords1AccessorModelFinal.getComponentType(),
+					false,
+					texcoords1AccessorModelFinal.getByteStride(),
+					texcoords1AccessorModelFinal.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		});
 		
 		int mode = meshPrimitiveModel.getMode();

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL30.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL30.java
@@ -346,6 +346,26 @@ public class RenderedGltfModelGL30 extends RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		ByteBuffer positionsBufferViewData = outputPositionsAccessorModel.getBufferViewModel().getBufferViewData();
@@ -504,6 +524,26 @@ public class RenderedGltfModelGL30 extends RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		ByteBuffer positionsBufferViewData = outputPositionsAccessorModel.getBufferViewModel().getBufferViewData();
@@ -669,6 +709,26 @@ public class RenderedGltfModelGL30 extends RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		ByteBuffer positionsBufferViewData = outputPositionsAccessorModel.getBufferViewModel().getBufferViewData();
 		ByteBuffer normalsBufferViewData = outputNormalsAccessorModel.getBufferViewModel().getBufferViewData();
@@ -800,6 +860,26 @@ public class RenderedGltfModelGL30 extends RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		ByteBuffer positionsBufferViewData = outputPositionsAccessorModel.getBufferViewModel().getBufferViewData();
@@ -936,6 +1016,26 @@ public class RenderedGltfModelGL30 extends RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		ByteBuffer positionsBufferViewData = outputPositionsAccessorModel.getBufferViewModel().getBufferViewData();
 		ByteBuffer normalsBufferViewData = outputNormalsAccessorModel.getBufferViewModel().getBufferViewData();

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL33.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL33.java
@@ -217,6 +217,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -414,6 +434,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -602,6 +642,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {
@@ -794,6 +854,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -981,6 +1061,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL11.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfScene.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfScene.java
@@ -49,7 +49,6 @@ public class RenderedGltfScene {
 			GL20.glUseProgram(currentProgram);
 		}
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL20.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL20.java
@@ -1,7 +1,6 @@
 package com.modularmods.mcgltf;
 
 import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL20;
 
 public class RenderedGltfSceneGL20 extends RenderedGltfScene {
 
@@ -16,7 +15,6 @@ public class RenderedGltfSceneGL20 extends RenderedGltfScene {
 
 	@Override
 	public void renderForShaderMod() {
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL30.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL30.java
@@ -1,7 +1,6 @@
 package com.modularmods.mcgltf;
 
 import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
 
 public class RenderedGltfSceneGL30 extends RenderedGltfScene {
@@ -18,7 +17,6 @@ public class RenderedGltfSceneGL30 extends RenderedGltfScene {
 
 	@Override
 	public void renderForShaderMod() {
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL33.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL33.java
@@ -39,7 +39,6 @@ public class RenderedGltfSceneGL33 extends RenderedGltfScene {
 			GL20.glUseProgram(currentProgram);
 		}
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL40.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL40.java
@@ -42,7 +42,6 @@ public class RenderedGltfSceneGL40 extends RenderedGltfScene {
 			GL20.glUseProgram(currentProgram);
 		}
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);

--- a/src/main/java/de/javagl/jgltf/model/AssetModel.java
+++ b/src/main/java/de/javagl/jgltf/model/AssetModel.java
@@ -1,0 +1,54 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+/**
+ * Interface for an asset. 
+ * 
+ * Note that this model does not include the version information that
+ * will eventually be written as the <code>gltf.asset.version</code>.
+ * This version information is <i>intentionally</i> hidden in the
+ * model, and will depend on the version in which the model will
+ * be written.
+ */
+public interface AssetModel extends NamedModelElement
+{
+    /**
+     * Returns the copyright message, suitable for display to credit
+     * the content creator.
+     * 
+     * @return The copyright message
+     */
+    String getCopyright();
+    
+    /**
+     * Returns the tool that generated this glTF model
+     * 
+     * @return The tool
+     */
+    String getGenerator();
+}

--- a/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
+++ b/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
@@ -1,0 +1,56 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+import java.util.List;
+
+/**
+ * An interface for the information about the extensions that are used in a
+ * {@link GltfModel}.
+ */
+public interface ExtensionsModel
+{
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsUsed</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of used extensions
+     */
+    List<String> getExtensionsUsed();
+
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsRequired</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of required extensions
+     */
+    List<String> getExtensionsRequired();
+}

--- a/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
+++ b/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
@@ -45,7 +45,7 @@ import de.javagl.jgltf.model.animation.InterpolatorType;
  * contain {@link Animation} instances that correspond to the 
  * {@link AnimationModel} instances of a glTF 
  */
-@Deprecated //Please use com.timlee9024.mcgltf.animation.GltfAnimationCreator to compatible with CUBICSPLINE interpolation
+@Deprecated //Please use com.modularmods.mcgltf.animation.GltfAnimationCreator to compatible with CUBICSPLINE interpolation
 public class GltfAnimations
 {
     /**

--- a/src/main/java/de/javagl/jgltf/model/GltfModel.java
+++ b/src/main/java/de/javagl/jgltf/model/GltfModel.java
@@ -129,5 +129,21 @@ public interface GltfModel extends ModelElement
      */
     List<TextureModel> getTextureModels();
     
+    /**
+     * Returns the {@link ExtensionsModel} that summarizes information
+     * about the extensions that are used in the glTF.
+     * 
+     * @return The {@link ExtensionsModel}
+     */
+    ExtensionsModel getExtensionsModel();
+    
+    /**
+     * Returns the {@link AssetModel} that contains information
+     * about the asset that is represented with this model.
+     * 
+     * @return The {@link AssetModel}
+     */
+    AssetModel getAssetModel();
+    
 }
 

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
@@ -1,0 +1,78 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import de.javagl.jgltf.model.AssetModel;
+
+/**
+ * Default implementation of an {@link AssetModel}
+ */
+public class DefaultAssetModel extends AbstractNamedModelElement
+    implements AssetModel
+{
+    /**
+     * The copyright
+     */
+    private String copyright;
+
+    /**
+     * The generator
+     */
+    private String generator;
+
+    /**
+     * Set the copyright
+     * 
+     * @param copyright The copyright
+     */
+    public void setCopyright(String copyright)
+    {
+        this.copyright = copyright;
+    }
+
+    @Override
+    public String getCopyright()
+    {
+        return copyright;
+    }
+
+    /**
+     * Set the generator
+     * 
+     * @param generator The generator
+     */
+    public void setGenerator(String generator)
+    {
+        this.generator = generator;
+    }
+
+    @Override
+    public String getGenerator()
+    {
+        return generator;
+    }
+}

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
@@ -1,0 +1,186 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import de.javagl.jgltf.model.ExtensionsModel;
+
+/**
+ * Default implementation of an {@link ExtensionsModel}.
+ * 
+ * This implementation ensures a certain degree of consistency for
+ * the extension information:
+ * <ul>
+ *   <li>
+ *     The extension names will always be unique
+ *   </li>
+ *   <li>
+ *     Adding an extension as "required" will also add it as "used"
+ *   </li>
+ *   <li>
+ *     Removing an extension as "used" will also remove it as "required"
+ *   </li>
+ * </ul>
+ * (Of course, adding a "used" extension will not add it as a "required" one,
+ * and <i>removing</i> a "required" extension will <i>not</i> remove it as 
+ * a "used" extension) 
+ */
+public class DefaultExtensionsModel implements ExtensionsModel
+{
+    /**
+     * The used extensions
+     */
+    private final Set<String> extensionsUsed;
+
+    /**
+     * The required extensions
+     */
+    private final Set<String> extensionsRequired;
+
+    /**
+     * Default constructor
+     */
+    public DefaultExtensionsModel()
+    {
+        this.extensionsUsed = new LinkedHashSet<String>();
+        this.extensionsRequired = new LinkedHashSet<String>();
+    }
+
+    /**
+     * Add the given extension name to the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionUsed(String extension)
+    {
+        this.extensionsUsed.add(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "used" extensions and
+     * from the list of "required" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionUsed(String extension)
+    {
+        this.extensionsUsed.remove(extension);
+        removeExtensionRequired(extension);
+    }
+
+    /**
+     * Add the given extension names to the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsUsed(Collection<String> extensions)
+    {
+        if (extensions != null) 
+        {
+            this.extensionsUsed.addAll(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "used" extensions and the list of "required" extensions
+     */
+    public void clearExtensionUsed()
+    {
+        this.extensionsUsed.clear();
+        clearExtensionRequired();
+    }
+
+    @Override
+    public List<String> getExtensionsUsed()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsUsed));
+    }
+
+    
+    /**
+     * Add the given extension name to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionRequired(String extension)
+    {
+        this.extensionsRequired.add(extension);
+        addExtensionUsed(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "required" extensions.
+     * 
+     * (Note that this will <i>not</i> remove the given extension name
+     * from the "used" extensions!)
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionRequired(String extension)
+    {
+        this.extensionsRequired.remove(extension);
+    }
+
+    /**
+     * Add the given extension names to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsRequired(Collection<String> extensions)
+    {
+        if (extensions != null)
+        {
+            this.extensionsRequired.addAll(extensions);
+            addExtensionsUsed(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "required" extensions.
+     */
+    public void clearExtensionRequired()
+    {
+        this.extensionsRequired.clear();
+    }
+    
+    @Override
+    public List<String> getExtensionsRequired()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsRequired));
+    }
+
+}

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
@@ -33,9 +33,11 @@ import java.util.List;
 
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -109,6 +111,16 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
      * The {@link TextureModel} instances
      */
     private final List<DefaultTextureModel> textureModels;
+    
+    /**
+     * The {@link ExtensionsModel}
+     */
+    private final DefaultExtensionsModel extensionsModel;
+    
+    /**
+     * The {@link AssetModel}
+     */
+    private final DefaultAssetModel assetModel;
 
     /**
      * Creates a new model 
@@ -127,6 +139,8 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
         this.sceneModels = new ArrayList<DefaultSceneModel>();
         this.skinModels = new ArrayList<DefaultSkinModel>();
         this.textureModels = new ArrayList<DefaultTextureModel>();
+        this.extensionsModel = new DefaultExtensionsModel();
+        this.assetModel = new DefaultAssetModel();
     }
     
     /**
@@ -835,5 +849,17 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
     public List<TextureModel> getTextureModels()
     {
         return Collections.unmodifiableList(textureModels);
+    }
+    
+    @Override
+    public DefaultExtensionsModel getExtensionsModel()
+    {
+        return extensionsModel;
+    }
+    
+    @Override
+    public DefaultAssetModel getAssetModel()
+    {
+        return assetModel;
     }
 }

--- a/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
+++ b/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
@@ -72,11 +72,13 @@ import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -382,9 +384,14 @@ public class GltfCreatorV1
             gltf.setScene(gltf.getScenes().keySet().iterator().next());
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("1.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
         gltf.setAsset(asset);
         
         return gltf;
@@ -1108,6 +1115,31 @@ public class GltfCreatorV1
         texture.setSource(imageIds.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("1.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
 
     /**

--- a/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -46,6 +46,7 @@ import de.javagl.jgltf.impl.v1.Animation;
 import de.javagl.jgltf.impl.v1.AnimationChannel;
 import de.javagl.jgltf.impl.v1.AnimationChannelTarget;
 import de.javagl.jgltf.impl.v1.AnimationSampler;
+import de.javagl.jgltf.impl.v1.Asset;
 import de.javagl.jgltf.impl.v1.Buffer;
 import de.javagl.jgltf.impl.v1.BufferView;
 import de.javagl.jgltf.impl.v1.Camera;
@@ -75,10 +76,12 @@ import de.javagl.jgltf.model.Accessors;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -108,11 +111,13 @@ import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
 import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -134,13 +139,28 @@ import net.minecraft.util.ResourceLocation;
  * A class that is responsible for filling a {@link DefaultGltfModel} with
  * the model instances that are created from a {@link GltfAssetV1}
  */
-class GltfModelCreatorV1
+public class GltfModelCreatorV1
 {
     /**
      * The logger used in this class
      */
     private static final Logger logger = 
         Logger.getLogger(GltfModelCreatorV1.class.getName());
+    
+    /**
+     * Create the {@link GltfModel} for the given {@link GltfAssetV1}
+     * 
+     * @param gltfAsset The {@link GltfAssetV1}
+     * @return The {@link GltfModel}
+     */
+    public static GltfModelV1 create(GltfAssetV1 gltfAsset)
+    {
+        GltfModelV1 gltfModel = new GltfModelV1();
+        GltfModelCreatorV1 creator = 
+            new GltfModelCreatorV1(gltfAsset, gltfModel);
+        creator.create();
+        return gltfModel;
+    }
     
     /**
      * The {@link IndexMappingSet}
@@ -220,6 +240,9 @@ class GltfModelCreatorV1
         initTextureModels();
         initShaderModels();
         initProgramModels();
+        
+        initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -1418,6 +1441,35 @@ class GltfModelCreatorV1
             materialModel.setValues(modelValues);
         }
     }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        // Note that glTF 1.0 only had 'extensionsUsed', no 'extensionsRequired'
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
+    }
+    
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     
     /**
      * Transfer the extensions and extras from the given property to

--- a/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -67,6 +67,7 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
 import de.javagl.jgltf.model.BufferModel;
@@ -74,6 +75,7 @@ import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -313,9 +315,20 @@ public class GltfCreatorV2
             gltf.setScene(0);
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("2.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
+        List<String> extensionsRequired = 
+            extensionsModel.getExtensionsRequired();
+        if (!extensionsRequired.isEmpty()) 
+        {
+            gltf.setExtensionsRequired(extensionsRequired);
+        }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
         gltf.setAsset(asset);
         
         return gltf;
@@ -951,6 +964,31 @@ public class GltfCreatorV2
         texture.setSource(imageIndices.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("2.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
     
     /**

--- a/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -42,6 +42,7 @@ import com.modularmods.mcgltf.MCglTF;
 
 import de.javagl.jgltf.impl.v2.GlTFChildOfRootProperty;
 import de.javagl.jgltf.impl.v2.GlTFProperty;
+import de.javagl.jgltf.impl.v2.Asset;
 import de.javagl.jgltf.impl.v2.Accessor;
 import de.javagl.jgltf.impl.v2.AccessorSparse;
 import de.javagl.jgltf.impl.v2.AccessorSparseIndices;
@@ -73,12 +74,14 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -94,6 +97,7 @@ import de.javagl.jgltf.model.impl.AbstractModelElement;
 import de.javagl.jgltf.model.impl.AbstractNamedModelElement;
 import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
@@ -101,6 +105,7 @@ import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -206,6 +211,9 @@ public class GltfModelCreatorV2
         initSkinModels();
         initTextureModels();
         initMaterialModels();
+        
+        initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -513,6 +521,11 @@ public class GltfModelCreatorV2
             BufferViewModel bufferViewModel = 
                 gltfModel.getBufferViewModel(bufferViewIndex);
             accessorModel.setBufferViewModel(bufferViewModel);
+            Integer byteStride = bufferViewModel.getByteStride();
+            if (byteStride != null)
+            {
+                accessorModel.setByteStride(byteStride);
+            }
             accessorModel.setAccessorData(AccessorDatas.create(accessorModel));
         }
         else
@@ -528,13 +541,6 @@ public class GltfModelCreatorV2
                 createBufferViewModel(uriString, bufferData);
             accessorModel.setBufferViewModel(bufferViewModel);
             accessorModel.setAccessorData(AccessorDatas.create(accessorModel));
-        }
-        
-        BufferViewModel bufferViewModel = accessorModel.getBufferViewModel(); 
-        Integer byteStride = bufferViewModel.getByteStride();
-        if (byteStride != null)
-        {
-            accessorModel.setByteStride(byteStride);
         }
     }
     
@@ -1287,7 +1293,36 @@ public class GltfModelCreatorV2
             material.defaultEmissiveFactor());
         materialModel.setEmissiveFactor(emissiveFactor);
     }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used or required in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        List<String> extensionsRequired = gltf.getExtensionsRequired();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
+        extensionsModel.addExtensionsRequired(extensionsRequired);
+    }
 
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     /**
      * Transfer the extensions and extras from the given property to
      * the given target

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "mcgltf",
   "name": "MCglTF",
   "description": "A glTF model loader library based on JglTF for Minecraft.",
-  "version": "1.12.2-Forge-2.0.0.1",
+  "version": "1.12.2-Forge-2.0.2.0",
   "mcversion": "1.12.2",
   "url": "www.curseforge.com/minecraft/mc-mods/mcgltf/",
   "updateUrl": "raw.githubusercontent.com/ModularMods/MCglTF/1.12.2-Forge/updates.json",

--- a/updates.json
+++ b/updates.json
@@ -1,6 +1,7 @@
 {
 	"homepage": "https://www.curseforge.com/minecraft/mc-mods/mcgltf/",
 	"1.12.2": {
+		"1.12.2-Forge-2.0.2.0": "More proper solution to the POM of BSL Shaders.",
 		"1.12.2-Forge-2.0.0.1": "Fix Exception not causing game crash but causing game hang during model loading.",
 		"1.12.2-Forge-2.0.0.0": "Update to meet Vanilla's minimun OpenGL requirement.",
 		"1.12.2-Forge-1.2.0.1": "Fix animation cause game crash, and an optimization forgot to reimplement in last update.",
@@ -11,7 +12,7 @@
 		"1.12.2-Forge-1.0.0.0": "Initial release"
 	},
 	"promos": {
-		"1.12.2-latest": "1.12.2-Forge-2.0.0.1",
-		"1.12.2-recommended": "1.12.2-Forge-2.0.0.1"
+		"1.12.2-latest": "1.12.2-Forge-2.0.2.0",
+		"1.12.2-recommended": "1.12.2-Forge-2.0.2.0"
 	}
 }


### PR DESCRIPTION
- Fix texture stretching if POM of BSL Shaders is enabled and texture coordinate of model is not in range of 0~1.
- Height map(alpha channel of normal map) is now working with POM of BSL Shaders, but require secondary UV channel(TEXCOORD_1 attribute of glTF) to defined UV center(mc_midTexCoord) of certain surface.
- Update to latest JglTF source.