### PR TITLE
Update to 2.0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.19.2-Forge-2.0.0.0'
+version = '1.19.2-Forge-2.0.2.0'
 group = 'com.modularmods.mcgltf' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'MCglTF'
 
@@ -129,7 +129,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19.2-43.1.52'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.2.1'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency

--- a/src/main/java/com/modularmods/mcgltf/MCglTF.java
+++ b/src/main/java/com/modularmods/mcgltf/MCglTF.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.apache.commons.io.IOUtils;
@@ -360,13 +361,13 @@ public class MCglTF {
 		GL20.glLinkProgram(glProgramSkinnig);
 	}
 	
-	private void processRenderedGltfModelsGL43(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup) {
+	private void processRenderedGltfModels(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup, BiFunction<List<Runnable>, GltfModel, RenderedGltfModel> renderedGltfModelBuilder) {
 		lookup.forEach((modelLocation, receivers) -> {
 			Iterator<IGltfModelReceiver> iterator = receivers.getRight().iterator();
 			do {
 				IGltfModelReceiver receiver = iterator.next();
 				if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-					RenderedGltfModel renderedModel = new RenderedGltfModel(gltfRenderData, receivers.getLeft());
+					RenderedGltfModel renderedModel = renderedGltfModelBuilder.apply(gltfRenderData, receivers.getLeft());
 					receiver.onReceiveSharedModel(renderedModel);
 					while(iterator.hasNext()) {
 						receiver = iterator.next();
@@ -379,77 +380,30 @@ public class MCglTF {
 			}
 			while(iterator.hasNext());
 		});
+	}
+	
+	private void processRenderedGltfModelsGL43(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup) {
+		processRenderedGltfModels(lookup, RenderedGltfModel::new);
 		GL15.glBindBuffer(GL30.GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 		GL15.glBindBuffer(GL43.GL_SHADER_STORAGE_BUFFER, 0);
 		GL40.glBindTransformFeedback(GL40.GL_TRANSFORM_FEEDBACK, 0);
 	}
 	
 	private void processRenderedGltfModelsGL40(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup) {
-		lookup.forEach((modelLocation, receivers) -> {
-			Iterator<IGltfModelReceiver> iterator = receivers.getRight().iterator();
-			do {
-				IGltfModelReceiver receiver = iterator.next();
-				if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-					RenderedGltfModel renderedModel = new RenderedGltfModelGL40(gltfRenderData, receivers.getLeft());
-					receiver.onReceiveSharedModel(renderedModel);
-					while(iterator.hasNext()) {
-						receiver = iterator.next();
-						if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-							receiver.onReceiveSharedModel(renderedModel);
-						}
-					}
-					return;
-				}
-			}
-			while(iterator.hasNext());
-		});
+		processRenderedGltfModels(lookup, RenderedGltfModelGL40::new);
 		GL15.glBindBuffer(GL30.GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 		GL15.glBindBuffer(GL31.GL_TEXTURE_BUFFER, 0);
 		GL40.glBindTransformFeedback(GL40.GL_TRANSFORM_FEEDBACK, 0);
 	}
 	
 	private void processRenderedGltfModelsGL33(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup) {
-		lookup.forEach((modelLocation, receivers) -> {
-			Iterator<IGltfModelReceiver> iterator = receivers.getRight().iterator();
-			do {
-				IGltfModelReceiver receiver = iterator.next();
-				if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-					RenderedGltfModel renderedModel = new RenderedGltfModelGL33(gltfRenderData, receivers.getLeft());
-					receiver.onReceiveSharedModel(renderedModel);
-					while(iterator.hasNext()) {
-						receiver = iterator.next();
-						if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-							receiver.onReceiveSharedModel(renderedModel);
-						}
-					}
-					return;
-				}
-			}
-			while(iterator.hasNext());
-		});
+		processRenderedGltfModels(lookup, RenderedGltfModelGL33::new);
 		GL15.glBindBuffer(GL30.GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 		GL15.glBindBuffer(GL31.GL_TEXTURE_BUFFER, 0);
 	}
 	
 	private void processRenderedGltfModelsGL30(Map<ResourceLocation, MutablePair<GltfModel, List<IGltfModelReceiver>>> lookup) {
-		lookup.forEach((modelLocation, receivers) -> {
-			Iterator<IGltfModelReceiver> iterator = receivers.getRight().iterator();
-			do {
-				IGltfModelReceiver receiver = iterator.next();
-				if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-					RenderedGltfModel renderedModel = new RenderedGltfModelGL30(gltfRenderData, receivers.getLeft());
-					receiver.onReceiveSharedModel(renderedModel);
-					while(iterator.hasNext()) {
-						receiver = iterator.next();
-						if(receiver.isReceiveSharedModel(receivers.getLeft(), gltfRenderData)) {
-							receiver.onReceiveSharedModel(renderedModel);
-						}
-					}
-					return;
-				}
-			}
-			while(iterator.hasNext());
-		});
+		processRenderedGltfModels(lookup, RenderedGltfModelGL30::new);
 	}
 	
 	public enum EnumRenderedModelGLProfile {

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
@@ -261,29 +261,7 @@ public class RenderedGltfModel {
 			vanillaRenderCommands.add(() -> {
 				float[] scale = nodeModel.getScale();
 				if(scale == null || scale[0] != 0.0F || scale[1] != 0.0F || scale[2] != 0.0F) {
-					Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
-					Matrix3f normal = new Matrix3f(pose);
-					
-					pose.transpose();
-					Matrix4f currentPose = CURRENT_POSE.copy();
-					currentPose.multiply(pose);
-					
-					normal.transpose();
-					Matrix3f currentNormal = CURRENT_NORMAL.copy();
-					currentNormal.mul(normal);
-					
-					CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-					CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
-					
-					currentNormal.transpose();
-					Vector3f light0Direction = LIGHT0_DIRECTION.copy();
-					Vector3f light1Direction = LIGHT1_DIRECTION.copy();
-					light0Direction.transform(currentNormal);
-					light1Direction.transform(currentNormal);
-					CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.set(light0Direction);
-					CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.set(light1Direction);
-					CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.upload();
-					CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.upload();
+					applyTransformVanilla(nodeModel);
 					
 					vanillaNodeRenderCommands.forEach(Runnable::run);
 				}
@@ -291,26 +269,7 @@ public class RenderedGltfModel {
 			shaderModRenderCommands.add(() -> {
 				float[] scale = nodeModel.getScale();
 				if(scale == null || scale[0] != 0.0F || scale[1] != 0.0F || scale[2] != 0.0F) {
-					Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
-					Matrix3f normal = new Matrix3f(pose);
-					
-					pose.transpose();
-					Matrix4f currentPose = CURRENT_POSE.copy();
-					currentPose.multiply(pose);
-					
-					normal.transpose();
-					Matrix3f currentNormal = CURRENT_NORMAL.copy();
-					currentNormal.mul(normal);
-					
-					currentPose.store(BUF_FLOAT_16);
-					GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
-					
-					currentPose.invert();
-					currentPose.store(BUF_FLOAT_16);
-					GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX_INVERSE, false, BUF_FLOAT_16);
-					
-					currentNormal.store(BUF_FLOAT_9);
-					GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+					applyTransformShaderMod(nodeModel);
 					
 					shaderModNodeRenderCommands.forEach(Runnable::run);
 				}
@@ -498,6 +457,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -628,6 +607,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -748,6 +747,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
+		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		int count = positionsAccessorModel.getCount();
@@ -872,6 +891,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -991,6 +1030,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
+		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		int count = positionsAccessorModel.getCount();
@@ -1268,6 +1327,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1485,6 +1564,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1692,6 +1791,26 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
+		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {
@@ -1903,6 +2022,26 @@ public class RenderedGltfModel {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -2110,11 +2249,80 @@ public class RenderedGltfModel {
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
 		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
+		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {
 			GL30.glBindVertexArray(glVertexArray);
 			GL40.glDrawTransformFeedback(mode, glTransformFeedback);
 		});
+	}
+	
+	protected void applyTransformVanilla(NodeModel nodeModel) {
+		Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
+		Matrix3f normal = new Matrix3f(pose);
+		
+		pose.transpose();
+		Matrix4f currentPose = CURRENT_POSE.copy();
+		currentPose.multiply(pose);
+		
+		normal.transpose();
+		Matrix3f currentNormal = CURRENT_NORMAL.copy();
+		currentNormal.mul(normal);
+		
+		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
+		CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
+		
+		currentNormal.transpose();
+		Vector3f light0Direction = LIGHT0_DIRECTION.copy();
+		Vector3f light1Direction = LIGHT1_DIRECTION.copy();
+		light0Direction.transform(currentNormal);
+		light1Direction.transform(currentNormal);
+		CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.set(light0Direction);
+		CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.set(light1Direction);
+		CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.upload();
+		CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.upload();
+	}
+	
+	protected void applyTransformShaderMod(NodeModel nodeModel) {
+		Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
+		Matrix3f normal = new Matrix3f(pose);
+		
+		pose.transpose();
+		Matrix4f currentPose = CURRENT_POSE.copy();
+		currentPose.multiply(pose);
+		
+		normal.transpose();
+		Matrix3f currentNormal = CURRENT_NORMAL.copy();
+		currentNormal.mul(normal);
+		
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
+		
+		currentPose.invert();
+		currentPose.store(BUF_FLOAT_16);
+		GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX_INVERSE, false, BUF_FLOAT_16);
+		
+		currentNormal.store(BUF_FLOAT_9);
+		GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
 	}
 	
 	public static class Material {

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModel.java
@@ -2088,7 +2088,6 @@ public class RenderedGltfModel {
 		
 		AccessorModel positionsAccessorModel = attributes.get("POSITION");
 		AccessorModel normalsAccessorModel = obtainNormalsAccessorModel(positionsAccessorModel);
-		AccessorModel texcoordsAccessorModel = attributes.get("TEXCOORD_0");
 		List<AccessorFloatData> targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
 		List<AccessorFloatData> normalTargetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
 		if(createPositionNormalMorphTarget(morphTargets, positionsAccessorModel, normalsAccessorModel, targetAccessorDatas, normalTargetAccessorDatas)) {
@@ -2134,6 +2133,7 @@ public class RenderedGltfModel {
 			GL20.glEnableVertexAttribArray(skinning_normal);
 		}
 		
+		AccessorModel texcoordsAccessorModel = attributes.get("TEXCOORD_0");
 		AccessorModel tangentsAccessorModel = obtainTangentsAccessorModel(normalsAccessorModel);
 		targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
 		if(createTangentMorphTarget(morphTargets, targetAccessorDatas, positionsAccessorModel, normalsAccessorModel, texcoordsAccessorModel, tangentsAccessorModel, normalTargetAccessorDatas)) {
@@ -3708,12 +3708,13 @@ public class RenderedGltfModel {
 		float weights[] = new float[targetAccessorDatas.size()];
 		int numComponents = 3;
 		int numElements = morphedAccessorData.getNumElements();
-		command.add(() -> {
-			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
-			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
-			
-			for(int e = 0; e < numElements; e++) {
-				for(int c = 0; c < numComponents; c++) {
+		
+		List<Runnable> morphingCommands = new ArrayList<Runnable>(numElements * numComponents);
+		for(int element = 0; element < numElements; element++) {
+			for(int component = 0; component < numComponents; component++) {
+				int e = element;
+				int c = component;
+				morphingCommands.add(() -> {
 					float r = baseAccessorData.get(e, c);
 					for(int i = 0; i < weights.length; i++) {
 						AccessorFloatData target = targetAccessorDatas.get(i);
@@ -3722,8 +3723,16 @@ public class RenderedGltfModel {
 						}
 					}
 					morphedAccessorData.set(e, c, r);
-				}
+				});
 			}
+		}
+		
+		command.add(() -> {
+			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
+			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
+			
+			morphingCommands.parallelStream().forEach(Runnable::run);
+			
 			GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, glBufferView);
 			GL15.glBufferSubData(GL15.GL_ARRAY_BUFFER, 0, morphedBufferViewData);
 		});
@@ -3764,12 +3773,13 @@ public class RenderedGltfModel {
 		float weights[] = new float[targetAccessorDatas.size()];
 		int numComponents = 4;
 		int numElements = morphedAccessorData.getNumElements();
-		command.add(() -> {
-			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
-			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
-			
-			for(int e = 0; e < numElements; e++) {
-				for(int c = 0; c < numComponents; c++) {
+		
+		List<Runnable> morphingCommands = new ArrayList<Runnable>(numElements * numComponents);
+		for(int element = 0; element < numElements; element++) {
+			for(int component = 0; component < numComponents; component++) {
+				int e = element;
+				int c = component;
+				morphingCommands.add(() -> {
 					float r = baseAccessorData.get(e, c);
 					for(int i = 0; i < weights.length; i++) {
 						AccessorFloatData target = targetAccessorDatas.get(i);
@@ -3778,8 +3788,16 @@ public class RenderedGltfModel {
 						}
 					}
 					morphedAccessorData.set(e, c, r);
-				}
+				});
 			}
+		}
+		
+		command.add(() -> {
+			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
+			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
+			
+			morphingCommands.parallelStream().forEach(Runnable::run);
+			
 			GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, glBufferView);
 			GL15.glBufferSubData(GL15.GL_ARRAY_BUFFER, 0, morphedBufferViewData);
 		});
@@ -3819,12 +3837,13 @@ public class RenderedGltfModel {
 		float weights[] = new float[targetAccessorDatas.size()];
 		int numComponents = 2;
 		int numElements = morphedAccessorData.getNumElements();
-		command.add(() -> {
-			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
-			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
-			
-			for(int e = 0; e < numElements; e++) {
-				for(int c = 0; c < numComponents; c++) {
+		
+		List<Runnable> morphingCommands = new ArrayList<Runnable>(numElements * numComponents);
+		for(int element = 0; element < numElements; element++) {
+			for(int component = 0; component < numComponents; component++) {
+				int e = element;
+				int c = component;
+				morphingCommands.add(() -> {
 					float r = baseAccessorData.get(e, c);
 					for(int i = 0; i < weights.length; i++) {
 						AccessorFloatData target = targetAccessorDatas.get(i);
@@ -3833,8 +3852,16 @@ public class RenderedGltfModel {
 						}
 					}
 					morphedAccessorData.set(e, c, r);
-				}
+				});
 			}
+		}
+		
+		command.add(() -> {
+			if(nodeModel.getWeights() != null) System.arraycopy(nodeModel.getWeights(), 0, weights, 0, weights.length);
+			else if(meshModel.getWeights() != null) System.arraycopy(meshModel.getWeights(), 0, weights, 0, weights.length);
+			
+			morphingCommands.parallelStream().forEach(Runnable::run);
+			
 			GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, glBufferView);
 			GL15.glBufferSubData(GL15.GL_ARRAY_BUFFER, 0, morphedBufferViewData);
 		});

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL33.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL33.java
@@ -231,6 +231,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -443,6 +463,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -646,6 +686,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
+		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {
@@ -853,6 +913,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 					texcoordsAccessorModel.getByteStride(),
 					texcoordsAccessorModel.getByteOffset());
 			GL20.glEnableVertexAttribArray(vaUV0);
+			
+			AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+			if(texcoords1AccessorModel != null) {
+				texcoordsAccessorModel = texcoords1AccessorModel;
+				targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+				if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+					texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+				}
+				else {
+					bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+				}
+			}
+			GL20.glVertexAttribPointer(
+					mc_midTexCoord,
+					texcoordsAccessorModel.getElementType().getNumComponents(),
+					texcoordsAccessorModel.getComponentType(),
+					false,
+					texcoordsAccessorModel.getByteStride(),
+					texcoordsAccessorModel.getByteOffset());
+			GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		}
 		
 		int mode = meshPrimitiveModel.getMode();
@@ -1055,6 +1135,26 @@ public class RenderedGltfModelGL33 extends RenderedGltfModelGL40 {
 				texcoordsAccessorModel.getByteStride(),
 				texcoordsAccessorModel.getByteOffset());
 		GL20.glEnableVertexAttribArray(vaUV0);
+		
+		AccessorModel texcoords1AccessorModel = attributes.get("TEXCOORD_1");
+		if(texcoords1AccessorModel != null) {
+			texcoordsAccessorModel = texcoords1AccessorModel;
+			targetAccessorDatas = new ArrayList<AccessorFloatData>(morphTargets.size());
+			if(createTexcoordMorphTarget(morphTargets, targetAccessorDatas)) {
+				texcoordsAccessorModel = bindTexcoordMorphed(gltfRenderData, nodeModel, meshModel, renderCommand, texcoordsAccessorModel, targetAccessorDatas);
+			}
+			else {
+				bindArrayBufferViewModel(gltfRenderData, texcoordsAccessorModel.getBufferViewModel());
+			}
+		}
+		GL20.glVertexAttribPointer(
+				mc_midTexCoord,
+				texcoordsAccessorModel.getElementType().getNumComponents(),
+				texcoordsAccessorModel.getComponentType(),
+				false,
+				texcoordsAccessorModel.getByteStride(),
+				texcoordsAccessorModel.getByteOffset());
+		GL20.glEnableVertexAttribArray(mc_midTexCoord);
 		
 		int mode = meshPrimitiveModel.getMode();
 		renderCommand.add(() -> {

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL40.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfModelGL40.java
@@ -6,13 +6,8 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Triple;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL31;
-
-import com.mojang.math.Matrix3f;
-import com.mojang.math.Matrix4f;
-import com.mojang.math.Vector3f;
 
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.MathUtils;
@@ -140,29 +135,7 @@ public class RenderedGltfModelGL40 extends RenderedGltfModel {
 			vanillaRenderCommands.add(() -> {
 				float[] scale = nodeModel.getScale();
 				if(scale == null || scale[0] != 0.0F || scale[1] != 0.0F || scale[2] != 0.0F) {
-					Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
-					Matrix3f normal = new Matrix3f(pose);
-					
-					pose.transpose();
-					Matrix4f currentPose = CURRENT_POSE.copy();
-					currentPose.multiply(pose);
-					
-					normal.transpose();
-					Matrix3f currentNormal = CURRENT_NORMAL.copy();
-					currentNormal.mul(normal);
-					
-					CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.set(currentPose);
-					CURRENT_SHADER_INSTANCE.MODEL_VIEW_MATRIX.upload();
-					
-					currentNormal.transpose();
-					Vector3f light0Direction = LIGHT0_DIRECTION.copy();
-					Vector3f light1Direction = LIGHT1_DIRECTION.copy();
-					light0Direction.transform(currentNormal);
-					light1Direction.transform(currentNormal);
-					CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.set(light0Direction);
-					CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.set(light1Direction);
-					CURRENT_SHADER_INSTANCE.LIGHT0_DIRECTION.upload();
-					CURRENT_SHADER_INSTANCE.LIGHT1_DIRECTION.upload();
+					applyTransformVanilla(nodeModel);
 					
 					vanillaNodeRenderCommands.forEach(Runnable::run);
 				}
@@ -170,26 +143,7 @@ public class RenderedGltfModelGL40 extends RenderedGltfModel {
 			shaderModRenderCommands.add(() -> {
 				float[] scale = nodeModel.getScale();
 				if(scale == null || scale[0] != 0.0F || scale[1] != 0.0F || scale[2] != 0.0F) {
-					Matrix4f pose = new Matrix4f(findGlobalTransform(nodeModel));
-					Matrix3f normal = new Matrix3f(pose);
-					
-					pose.transpose();
-					Matrix4f currentPose = CURRENT_POSE.copy();
-					currentPose.multiply(pose);
-					
-					normal.transpose();
-					Matrix3f currentNormal = CURRENT_NORMAL.copy();
-					currentNormal.mul(normal);
-					
-					currentPose.store(BUF_FLOAT_16);
-					GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX, false, BUF_FLOAT_16);
-					
-					currentPose.invert();
-					currentPose.store(BUF_FLOAT_16);
-					GL20.glUniformMatrix4fv(MODEL_VIEW_MATRIX_INVERSE, false, BUF_FLOAT_16);
-					
-					currentNormal.store(BUF_FLOAT_9);
-					GL20.glUniformMatrix3fv(NORMAL_MATRIX, false, BUF_FLOAT_9);
+					applyTransformShaderMod(nodeModel);
 					
 					shaderModNodeRenderCommands.forEach(Runnable::run);
 				}

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfScene.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfScene.java
@@ -108,7 +108,6 @@ public class RenderedGltfScene {
 		GL13.glActiveTexture(GL13.GL_TEXTURE0);
 		int currentTexture0 = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL13.glActiveTexture(GL13.GL_TEXTURE3);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL30.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL30.java
@@ -78,7 +78,6 @@ public class RenderedGltfSceneGL30 extends RenderedGltfScene {
 		GL13.glActiveTexture(GL13.GL_TEXTURE0);
 		int currentTexture0 = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL13.glActiveTexture(GL13.GL_TEXTURE3);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL33.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL33.java
@@ -98,7 +98,6 @@ public class RenderedGltfSceneGL33 extends RenderedGltfScene {
 		GL13.glActiveTexture(GL13.GL_TEXTURE0);
 		int currentTexture0 = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL13.glActiveTexture(GL13.GL_TEXTURE3);

--- a/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL40.java
+++ b/src/main/java/com/modularmods/mcgltf/RenderedGltfSceneGL40.java
@@ -101,7 +101,6 @@ public class RenderedGltfSceneGL40 extends RenderedGltfScene {
 		GL13.glActiveTexture(GL13.GL_TEXTURE0);
 		int currentTexture0 = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
 		
-		GL20.glVertexAttrib2f(RenderedGltfModel.mc_midTexCoord, 1.0F, 1.0F);
 		shaderModRenderCommands.forEach(Runnable::run);
 		
 		GL13.glActiveTexture(GL13.GL_TEXTURE3);

--- a/src/main/java/de/javagl/jgltf/model/AssetModel.java
+++ b/src/main/java/de/javagl/jgltf/model/AssetModel.java
@@ -1,0 +1,54 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+/**
+ * Interface for an asset. 
+ * 
+ * Note that this model does not include the version information that
+ * will eventually be written as the <code>gltf.asset.version</code>.
+ * This version information is <i>intentionally</i> hidden in the
+ * model, and will depend on the version in which the model will
+ * be written.
+ */
+public interface AssetModel extends NamedModelElement
+{
+    /**
+     * Returns the copyright message, suitable for display to credit
+     * the content creator.
+     * 
+     * @return The copyright message
+     */
+    String getCopyright();
+    
+    /**
+     * Returns the tool that generated this glTF model
+     * 
+     * @return The tool
+     */
+    String getGenerator();
+}

--- a/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
+++ b/src/main/java/de/javagl/jgltf/model/ExtensionsModel.java
@@ -1,0 +1,56 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model;
+
+import java.util.List;
+
+/**
+ * An interface for the information about the extensions that are used in a
+ * {@link GltfModel}.
+ */
+public interface ExtensionsModel
+{
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsUsed</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of used extensions
+     */
+    List<String> getExtensionsUsed();
+
+    /**
+     * Returns the list of extension names that are declared as the
+     * <code>extensionsRequired</code> in the glTF asset.
+     * 
+     * The list should be assumed to be unmodifiable.
+     * 
+     * @return The list of required extensions
+     */
+    List<String> getExtensionsRequired();
+}

--- a/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
+++ b/src/main/java/de/javagl/jgltf/model/GltfAnimations.java
@@ -45,7 +45,7 @@ import de.javagl.jgltf.model.animation.InterpolatorType;
  * contain {@link Animation} instances that correspond to the 
  * {@link AnimationModel} instances of a glTF 
  */
-@Deprecated //Please use com.timlee9024.mcgltf.animation.GltfAnimationCreator to compatible with CUBICSPLINE interpolation
+@Deprecated //Please use com.modularmods.mcgltf.animation.GltfAnimationCreator to compatible with CUBICSPLINE interpolation
 public class GltfAnimations
 {
     /**

--- a/src/main/java/de/javagl/jgltf/model/GltfModel.java
+++ b/src/main/java/de/javagl/jgltf/model/GltfModel.java
@@ -129,5 +129,21 @@ public interface GltfModel extends ModelElement
      */
     List<TextureModel> getTextureModels();
     
+    /**
+     * Returns the {@link ExtensionsModel} that summarizes information
+     * about the extensions that are used in the glTF.
+     * 
+     * @return The {@link ExtensionsModel}
+     */
+    ExtensionsModel getExtensionsModel();
+    
+    /**
+     * Returns the {@link AssetModel} that contains information
+     * about the asset that is represented with this model.
+     * 
+     * @return The {@link AssetModel}
+     */
+    AssetModel getAssetModel();
+    
 }
 

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultAssetModel.java
@@ -1,0 +1,78 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import de.javagl.jgltf.model.AssetModel;
+
+/**
+ * Default implementation of an {@link AssetModel}
+ */
+public class DefaultAssetModel extends AbstractNamedModelElement
+    implements AssetModel
+{
+    /**
+     * The copyright
+     */
+    private String copyright;
+
+    /**
+     * The generator
+     */
+    private String generator;
+
+    /**
+     * Set the copyright
+     * 
+     * @param copyright The copyright
+     */
+    public void setCopyright(String copyright)
+    {
+        this.copyright = copyright;
+    }
+
+    @Override
+    public String getCopyright()
+    {
+        return copyright;
+    }
+
+    /**
+     * Set the generator
+     * 
+     * @param generator The generator
+     */
+    public void setGenerator(String generator)
+    {
+        this.generator = generator;
+    }
+
+    @Override
+    public String getGenerator()
+    {
+        return generator;
+    }
+}

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultExtensionsModel.java
@@ -1,0 +1,186 @@
+/*
+ * www.javagl.de - JglTF
+ *
+ * Copyright 2015-2017 Marco Hutter - http://www.javagl.de
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package de.javagl.jgltf.model.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import de.javagl.jgltf.model.ExtensionsModel;
+
+/**
+ * Default implementation of an {@link ExtensionsModel}.
+ * 
+ * This implementation ensures a certain degree of consistency for
+ * the extension information:
+ * <ul>
+ *   <li>
+ *     The extension names will always be unique
+ *   </li>
+ *   <li>
+ *     Adding an extension as "required" will also add it as "used"
+ *   </li>
+ *   <li>
+ *     Removing an extension as "used" will also remove it as "required"
+ *   </li>
+ * </ul>
+ * (Of course, adding a "used" extension will not add it as a "required" one,
+ * and <i>removing</i> a "required" extension will <i>not</i> remove it as 
+ * a "used" extension) 
+ */
+public class DefaultExtensionsModel implements ExtensionsModel
+{
+    /**
+     * The used extensions
+     */
+    private final Set<String> extensionsUsed;
+
+    /**
+     * The required extensions
+     */
+    private final Set<String> extensionsRequired;
+
+    /**
+     * Default constructor
+     */
+    public DefaultExtensionsModel()
+    {
+        this.extensionsUsed = new LinkedHashSet<String>();
+        this.extensionsRequired = new LinkedHashSet<String>();
+    }
+
+    /**
+     * Add the given extension name to the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionUsed(String extension)
+    {
+        this.extensionsUsed.add(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "used" extensions and
+     * from the list of "required" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionUsed(String extension)
+    {
+        this.extensionsUsed.remove(extension);
+        removeExtensionRequired(extension);
+    }
+
+    /**
+     * Add the given extension names to the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsUsed(Collection<String> extensions)
+    {
+        if (extensions != null) 
+        {
+            this.extensionsUsed.addAll(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "used" extensions and the list of "required" extensions
+     */
+    public void clearExtensionUsed()
+    {
+        this.extensionsUsed.clear();
+        clearExtensionRequired();
+    }
+
+    @Override
+    public List<String> getExtensionsUsed()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsUsed));
+    }
+
+    
+    /**
+     * Add the given extension name to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extension The extension name.
+     */
+    public void addExtensionRequired(String extension)
+    {
+        this.extensionsRequired.add(extension);
+        addExtensionUsed(extension);
+    }
+
+    /**
+     * Remove the given extension name from the "required" extensions.
+     * 
+     * (Note that this will <i>not</i> remove the given extension name
+     * from the "used" extensions!)
+     * 
+     * @param extension The extension name.
+     */
+    public void removeExtensionRequired(String extension)
+    {
+        this.extensionsRequired.remove(extension);
+    }
+
+    /**
+     * Add the given extension names to the "required" extensions and to
+     * the "used" extensions.
+     * 
+     * @param extensions The extension names
+     */
+    public void addExtensionsRequired(Collection<String> extensions)
+    {
+        if (extensions != null)
+        {
+            this.extensionsRequired.addAll(extensions);
+            addExtensionsUsed(extensions);
+        }
+    }
+
+    /**
+     * Clear the list of "required" extensions.
+     */
+    public void clearExtensionRequired()
+    {
+        this.extensionsRequired.clear();
+    }
+    
+    @Override
+    public List<String> getExtensionsRequired()
+    {
+        return Collections.unmodifiableList(
+            new ArrayList<String>(extensionsRequired));
+    }
+
+}

--- a/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
+++ b/src/main/java/de/javagl/jgltf/model/impl/DefaultGltfModel.java
@@ -33,9 +33,11 @@ import java.util.List;
 
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -109,6 +111,16 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
      * The {@link TextureModel} instances
      */
     private final List<DefaultTextureModel> textureModels;
+    
+    /**
+     * The {@link ExtensionsModel}
+     */
+    private final DefaultExtensionsModel extensionsModel;
+    
+    /**
+     * The {@link AssetModel}
+     */
+    private final DefaultAssetModel assetModel;
 
     /**
      * Creates a new model 
@@ -127,6 +139,8 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
         this.sceneModels = new ArrayList<DefaultSceneModel>();
         this.skinModels = new ArrayList<DefaultSkinModel>();
         this.textureModels = new ArrayList<DefaultTextureModel>();
+        this.extensionsModel = new DefaultExtensionsModel();
+        this.assetModel = new DefaultAssetModel();
     }
     
     /**
@@ -835,5 +849,17 @@ public class DefaultGltfModel extends AbstractModelElement implements GltfModel
     public List<TextureModel> getTextureModels()
     {
         return Collections.unmodifiableList(textureModels);
+    }
+    
+    @Override
+    public DefaultExtensionsModel getExtensionsModel()
+    {
+        return extensionsModel;
+    }
+    
+    @Override
+    public DefaultAssetModel getAssetModel()
+    {
+        return assetModel;
     }
 }

--- a/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
+++ b/src/main/java/de/javagl/jgltf/model/v1/GltfCreatorV1.java
@@ -72,11 +72,13 @@ import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -382,9 +384,14 @@ public class GltfCreatorV1
             gltf.setScene(gltf.getScenes().keySet().iterator().next());
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("1.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
         gltf.setAsset(asset);
         
         return gltf;
@@ -1108,6 +1115,31 @@ public class GltfCreatorV1
         texture.setSource(imageIds.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("1.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
 
     /**

--- a/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
+++ b/src/main/java/de/javagl/jgltf/model/v1/GltfModelCreatorV1.java
@@ -46,6 +46,7 @@ import de.javagl.jgltf.impl.v1.Animation;
 import de.javagl.jgltf.impl.v1.AnimationChannel;
 import de.javagl.jgltf.impl.v1.AnimationChannelTarget;
 import de.javagl.jgltf.impl.v1.AnimationSampler;
+import de.javagl.jgltf.impl.v1.Asset;
 import de.javagl.jgltf.impl.v1.Buffer;
 import de.javagl.jgltf.impl.v1.BufferView;
 import de.javagl.jgltf.impl.v1.Camera;
@@ -75,10 +76,12 @@ import de.javagl.jgltf.model.Accessors;
 import de.javagl.jgltf.model.AnimationModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -108,11 +111,13 @@ import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
 import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -134,13 +139,28 @@ import net.minecraft.resources.ResourceLocation;
  * A class that is responsible for filling a {@link DefaultGltfModel} with
  * the model instances that are created from a {@link GltfAssetV1}
  */
-class GltfModelCreatorV1
+public class GltfModelCreatorV1
 {
     /**
      * The logger used in this class
      */
     private static final Logger logger = 
         Logger.getLogger(GltfModelCreatorV1.class.getName());
+    
+    /**
+     * Create the {@link GltfModel} for the given {@link GltfAssetV1}
+     * 
+     * @param gltfAsset The {@link GltfAssetV1}
+     * @return The {@link GltfModel}
+     */
+    public static GltfModelV1 create(GltfAssetV1 gltfAsset)
+    {
+        GltfModelV1 gltfModel = new GltfModelV1();
+        GltfModelCreatorV1 creator = 
+            new GltfModelCreatorV1(gltfAsset, gltfModel);
+        creator.create();
+        return gltfModel;
+    }
     
     /**
      * The {@link IndexMappingSet}
@@ -220,6 +240,9 @@ class GltfModelCreatorV1
         initTextureModels();
         initShaderModels();
         initProgramModels();
+        
+        initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -1418,6 +1441,35 @@ class GltfModelCreatorV1
             materialModel.setValues(modelValues);
         }
     }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        // Note that glTF 1.0 only had 'extensionsUsed', no 'extensionsRequired'
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
+    }
+    
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     
     /**
      * Transfer the extensions and extras from the given property to

--- a/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
+++ b/src/main/java/de/javagl/jgltf/model/v2/GltfCreatorV2.java
@@ -67,6 +67,7 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Sampler;
 import de.javagl.jgltf.model.BufferModel;
@@ -74,6 +75,7 @@ import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.CameraOrthographicModel;
 import de.javagl.jgltf.model.CameraPerspectiveModel;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
 import de.javagl.jgltf.model.MaterialModel;
@@ -313,9 +315,20 @@ public class GltfCreatorV2
             gltf.setScene(0);
         }
         
-        Asset asset = new Asset();
-        asset.setVersion("2.0");
-        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        ExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        List<String> extensionsUsed = extensionsModel.getExtensionsUsed();
+        if (!extensionsUsed.isEmpty()) 
+        {
+            gltf.setExtensionsUsed(extensionsUsed);
+        }
+        List<String> extensionsRequired = 
+            extensionsModel.getExtensionsRequired();
+        if (!extensionsRequired.isEmpty()) 
+        {
+            gltf.setExtensionsRequired(extensionsRequired);
+        }
+        
+        Asset asset = createAsset(gltfModel.getAssetModel());
         gltf.setAsset(asset);
         
         return gltf;
@@ -951,6 +964,31 @@ public class GltfCreatorV2
         texture.setSource(imageIndices.get(textureModel.getImageModel()));
         
         return texture;
+    }
+    
+    /**
+     * Creates an asset for the given {@link AssetModel}
+     * 
+     * @param assetModel The {@link AssetModel}
+     * @return The {@link Asset}
+     */
+    private Asset createAsset(AssetModel assetModel)
+    {
+        Asset asset = new Asset();
+        asset.setVersion("2.0");
+        asset.setGenerator("JglTF from https://github.com/javagl/JglTF");
+        
+        transferGltfPropertyElements(assetModel, asset);
+        
+        if (assetModel.getCopyright() != null)
+        {
+            asset.setCopyright(assetModel.getCopyright());
+        }
+        if (assetModel.getGenerator() != null)
+        {
+            asset.setGenerator(assetModel.getGenerator());
+        }
+        return asset;
     }
     
     /**

--- a/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
+++ b/src/main/java/de/javagl/jgltf/model/v2/GltfModelCreatorV2.java
@@ -42,6 +42,7 @@ import com.modularmods.mcgltf.MCglTF;
 
 import de.javagl.jgltf.impl.v2.GlTFChildOfRootProperty;
 import de.javagl.jgltf.impl.v2.GlTFProperty;
+import de.javagl.jgltf.impl.v2.Asset;
 import de.javagl.jgltf.impl.v2.Accessor;
 import de.javagl.jgltf.impl.v2.AccessorSparse;
 import de.javagl.jgltf.impl.v2.AccessorSparseIndices;
@@ -73,12 +74,14 @@ import de.javagl.jgltf.model.AccessorData;
 import de.javagl.jgltf.model.AccessorDatas;
 import de.javagl.jgltf.model.AccessorModel;
 import de.javagl.jgltf.model.AnimationModel;
+import de.javagl.jgltf.model.AssetModel;
 import de.javagl.jgltf.model.AnimationModel.Channel;
 import de.javagl.jgltf.model.AnimationModel.Interpolation;
 import de.javagl.jgltf.model.BufferModel;
 import de.javagl.jgltf.model.BufferViewModel;
 import de.javagl.jgltf.model.CameraModel;
 import de.javagl.jgltf.model.ElementType;
+import de.javagl.jgltf.model.ExtensionsModel;
 import de.javagl.jgltf.model.GltfConstants;
 import de.javagl.jgltf.model.GltfModel;
 import de.javagl.jgltf.model.ImageModel;
@@ -94,6 +97,7 @@ import de.javagl.jgltf.model.impl.AbstractModelElement;
 import de.javagl.jgltf.model.impl.AbstractNamedModelElement;
 import de.javagl.jgltf.model.impl.DefaultAccessorModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel;
+import de.javagl.jgltf.model.impl.DefaultAssetModel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultChannel;
 import de.javagl.jgltf.model.impl.DefaultAnimationModel.DefaultSampler;
 import de.javagl.jgltf.model.impl.DefaultBufferModel;
@@ -101,6 +105,7 @@ import de.javagl.jgltf.model.impl.DefaultBufferViewModel;
 import de.javagl.jgltf.model.impl.DefaultCameraModel;
 import de.javagl.jgltf.model.impl.DefaultCameraOrthographicModel;
 import de.javagl.jgltf.model.impl.DefaultCameraPerspectiveModel;
+import de.javagl.jgltf.model.impl.DefaultExtensionsModel;
 import de.javagl.jgltf.model.impl.DefaultGltfModel;
 import de.javagl.jgltf.model.impl.DefaultImageModel;
 import de.javagl.jgltf.model.impl.DefaultMeshModel;
@@ -206,6 +211,9 @@ public class GltfModelCreatorV2
         initSkinModels();
         initTextureModels();
         initMaterialModels();
+        
+        initExtensionsModel();
+        initAssetModel();
     }
     
     /**
@@ -513,6 +521,11 @@ public class GltfModelCreatorV2
             BufferViewModel bufferViewModel = 
                 gltfModel.getBufferViewModel(bufferViewIndex);
             accessorModel.setBufferViewModel(bufferViewModel);
+            Integer byteStride = bufferViewModel.getByteStride();
+            if (byteStride != null)
+            {
+                accessorModel.setByteStride(byteStride);
+            }
             accessorModel.setAccessorData(AccessorDatas.create(accessorModel));
         }
         else
@@ -528,13 +541,6 @@ public class GltfModelCreatorV2
                 createBufferViewModel(uriString, bufferData);
             accessorModel.setBufferViewModel(bufferViewModel);
             accessorModel.setAccessorData(AccessorDatas.create(accessorModel));
-        }
-        
-        BufferViewModel bufferViewModel = accessorModel.getBufferViewModel(); 
-        Integer byteStride = bufferViewModel.getByteStride();
-        if (byteStride != null)
-        {
-            accessorModel.setByteStride(byteStride);
         }
     }
     
@@ -1287,7 +1293,36 @@ public class GltfModelCreatorV2
             material.defaultEmissiveFactor());
         materialModel.setEmissiveFactor(emissiveFactor);
     }
+    
+    /**
+     * Initialize the {@link ExtensionsModel} with the extensions that
+     * are used or required in the glTF.
+     */
+    private void initExtensionsModel() 
+    {
+        List<String> extensionsUsed = gltf.getExtensionsUsed();
+        List<String> extensionsRequired = gltf.getExtensionsRequired();
+        DefaultExtensionsModel extensionsModel = gltfModel.getExtensionsModel();
+        extensionsModel.addExtensionsUsed(extensionsUsed);
+        extensionsModel.addExtensionsRequired(extensionsRequired);
+    }
 
+    /**
+     * Initialize the {@link AssetModel} with the asset information that
+     * was given in the glTF.
+     */
+    private void initAssetModel() 
+    {
+        Asset asset = gltf.getAsset();
+        if (asset != null)
+        {
+            DefaultAssetModel assetModel = gltfModel.getAssetModel();
+            transferGltfPropertyElements(asset, assetModel);
+            assetModel.setCopyright(asset.getCopyright());
+            assetModel.setGenerator(asset.getGenerator());
+        }
+    }
+    
     /**
      * Transfer the extensions and extras from the given property to
      * the given target

--- a/updates.json
+++ b/updates.json
@@ -1,9 +1,11 @@
 {
 	"homepage": "https://www.curseforge.com/minecraft/mc-mods/mcgltf/",
 	"1.19.2": {
+		"1.19.2-Forge-2.0.2.0": "More proper solution to the POM of BSL Shaders.",
 		"1.19.2-Forge-2.0.0.0": "Update to meet Vanilla's minimun OpenGL requirement."
 	},
 	"1.19": {
+		"1.19.2-Forge-2.0.2.0": "More proper solution to the POM of BSL Shaders.",
 		"1.19.2-Forge-2.0.0.0": "Update to meet Vanilla's minimun OpenGL requirement.",
 		"1.19-Forge-1.2.0.1": "Fix animation cause game crash, and an optimization forgot to reimplement in last update.",
 		"1.19-Forge-1.2.0.0": "This update break compatibility with previous version, please visit homepage for more info.",
@@ -11,9 +13,9 @@
 		"1.19-Forge-1.0.0.0": "Initial release"
 	},
 	"promos": {
-		"1.19.2-latest": "1.19.2-Forge-2.0.0.0",
-		"1.19.2-recommended": "1.19.2-Forge-2.0.0.0",
-		"1.19-latest": "1.19.2-Forge-2.0.0.0",
-		"1.19-recommended": "1.19.2-Forge-2.0.0.0"
+		"1.19.2-latest": "1.19.2-Forge-2.0.2.0",
+		"1.19.2-recommended": "1.19.2-Forge-2.0.2.0",
+		"1.19-latest": "1.19.2-Forge-2.0.2.0",
+		"1.19-recommended": "1.19.2-Forge-2.0.2.0"
 	}
 }


### PR DESCRIPTION
- Fix texture stretching if POM of BSL Shaders is enabled and texture coordinate of model is not in range of 0~1.
- Height map(alpha channel of normal map) is now working with POM of BSL Shaders, but require secondary UV channel(TEXCOORD_1 attribute of glTF) to defined UV center(mc_midTexCoord) of certain surface.
- Update to latest JglTF source.
- Re-add multi-threaded Morphing that is forgotten in 2.0 release.